### PR TITLE
RunHelpers#change_line in Ruby 1.9

### DIFF
--- a/lib/babushka/helpers/run_helpers.rb
+++ b/lib/babushka/helpers/run_helpers.rb
@@ -39,7 +39,7 @@ module Babushka
       log "Patching #{path}"
       sudo "cat > #{path}", :as => path.owner, :input => path.readlines.map {|l|
         l.gsub /^(\s*)(#{Regexp.escape(line)})/, "\\1# #{edited_by_babushka}\n\\1# was: \\2\n\\1#{replacement}"
-      }
+      }.join("")
     end
 
     def insert_into_file insert_before, path, lines, opts = {}

--- a/spec/babushka/run_helpers_spec.rb
+++ b/spec/babushka/run_helpers_spec.rb
@@ -13,3 +13,14 @@ describe "grep" do
     RunTester.grep('lol', '/nonexistent').should be_nil
   end
 end
+
+describe "change_line" do
+  path = "#{tmp_prefix}/babushka_run_helper_change_line"
+  it "should not mangle a file" do
+    File.open(path, "w") { |f| f.write "one\ntwo\nthree\n" }
+    RunTester.change_line("two", "changed", path)
+    lines = File.open(path, "r") { |f| f.readlines.map{ |l| l.chomp } }
+    lines.values_at(0,3,4).should == ["one", "changed", "three"]
+    lines.length.should == 5 # two comments added
+  end
+end


### PR DESCRIPTION
RunHelpers#change_line is broken in Ruby 1.9 due to the change in Array#to_s behaviour.

I've patched it, added spec coverage, and tested in 1.8.7 and 1.9.2 under Linux and Mac OS X.

Cheers!
Paul
