### PR TITLE
Meta :installer only tests --version for commands in var(:versions).

### DIFF
--- a/deps/templates/installer.rb
+++ b/deps/templates/installer.rb
@@ -6,7 +6,7 @@ meta :installer do
 
   template {
     helper :current_version? do
-      provides.all? {|p|
+      (provides & var(:versions).keys).all? {|p|
         shell("#{p} --version").split(/[\s\-]/).include? var(:versions)[p.to_s]
       }
     end


### PR DESCRIPTION
In creating a [VirtualBox dep](https://github.com/pda/babushka-deps/blob/master/virtualbox.rb) using the `:installer` meta template, I had trouble with commands provided by VirtualBox being tested for `--version`.

The `VirtualBox` command launches a GUI which blocks Babushka.  It's possible that I shouldn't be including GUI-launching commands in `provides`.  However, the `--version` check is pointless anyway, because there's nothing to compare it against in `var(:versions)`. 

I've patched the `:installer` template to only `--version` check commands that exist in `var(:versions)`.

Cheers,
Paul 
