### PR TITLE
small fix to resource lib

### DIFF
--- a/lib/babushka/resource.rb
+++ b/lib/babushka/resource.rb
@@ -32,7 +32,7 @@ module Babushka
         filename
       elsif (result = shell(%Q{curl -I -X GET "#{url}"})).nil?
         log_error "Couldn't download #{url}: `curl` exited with non-zero status."
-      elsif (response_code = result.val_for("HTTP/1.1"))[/^[23]/].nil?
+      elsif (response_code = result.val_for("HTTP/1.0") || result.val_for("HTTP/1.1"))[/^[23]/].nil?
         log_error "Couldn't download #{url}: #{response_code}."
       elsif !(location = result.val_for('Location')).nil?
         log "Following redirect from #{url}"


### PR DESCRIPTION
I've added fast fix to http code detection during downloading with curl. Because any dep that uses 'handle_source' breaks on 'HTTP/1.0' respond. I've found this issue when tried to install 'rubygems' dep.
