### PR TITLE
LogHelpers#write_to_persistent_log flushes log; eliminate output lag.

### DIFF
--- a/lib/babushka/helpers/log_helpers.rb
+++ b/lib/babushka/helpers/log_helpers.rb
@@ -155,7 +155,12 @@ module Babushka
     end
 
     def write_to_persistent_log message
-      Base.task.persistent_log.write message unless Base.task.persistent_log.nil?
+      Base.task.persistent_log.tap do |log|
+        if log
+          log.write message
+          log.flush
+        end
+      end
     end
 
     def indentation


### PR DESCRIPTION
Flushes the persistent log on every write, so that tail -f can give clues into why a command is slow/stalled. This is something that frequently frustrates me.. I think any slow-down caused by frequent flushing is worth it.

I couldn't think of a more elegant way to express the code, without refactoring the way Task#persistent_log works.
