### PR TITLE
Escape URLs which we are about to follow

### DIFF
--- a/lib/babushka/resource.rb
+++ b/lib/babushka/resource.rb
@@ -38,7 +38,7 @@ module Babushka
           log_error "Couldn't download #{url}: #{response_code}."
         elsif !(location = result.val_for('Location')).nil?
           log "Following redirect from #{url}"
-          download location, location.p.basename
+          download URI.escape(location), location.p.basename
         else
           success = log_block "Downloading #{url}" do
             shell %Q{curl -# -o "#{filename}.tmp" "#{url}" && mv -f "#{filename}.tmp" "#{filename}"}, :progress => /[\d\.]+%/


### PR DESCRIPTION
Hi there,

a small yet essential fix for Babushka::Resource.download. An URL to test with could be for GitHub's Mac client, i.e. https://central.github.com/mac/latest . Haven't found any specs for the download method. Should I write one? It looks like that it would involve heavy mockery.

And BTW, thank you for babushka, it is a nice piece of software ;)
