### PR TITLE
add a default_for_ask option that can be triggered programatically

### DIFF
--- a/lib/babushka/vars.rb
+++ b/lib/babushka/vars.rb
@@ -10,11 +10,13 @@ module Babushka
       def merge(key, value) Base.task.vars.merge(key, value) end
       def var(name, opts = {}) Base.task.vars.var(name, opts) end
       def define_var(name, opts = {}) Base.task.vars.define_var(name, opts) end
+      def default_for_ask(bool) Base.task.vars.default_for_ask(bool) end
     end
 
     def initialize
       @vars = Hashish.hash
       @saved_vars = Hashish.hash
+      @default_for_ask = true
     end
 
     def set key, value
@@ -26,6 +28,7 @@ module Babushka
 
     def var name, opts = {}
       define_var name, opts
+      opts[:ask] = @default_for_ask unless opts.has_key? :ask
       if vars[name.to_s].has_key? :value
         if vars[name.to_s][:value].respond_to? :call
           vars[name.to_s][:value].call
@@ -37,6 +40,10 @@ module Babushka
       else
         default_for name
       end
+    end
+
+    def default_for_ask(bool)
+      @default_for_ask = bool
     end
 
     def define_var name, opts = {}


### PR DESCRIPTION
When requiring external deps (like your webapp dep) in one of my deps, I often set pre-set variables that will be needed by the external deps. This is often just the default option. I thought it would be nice to be able to programatically turn --defaults on and off. If there already is a way, please let me know.

cheers,
robin
