### PR TITLE
Install mac app bundles via sparkle

### DIFF
--- a/deps/templates/app.rb
+++ b/deps/templates/app.rb
@@ -51,7 +51,7 @@ meta :app do
 
   template {
     prepare {
-      unless sparkle.empty?
+      unless sparkle.blank?
         def source
           get_source_from_sparkle
         end


### PR DESCRIPTION
Not sure if this is the completely correct approach, but this allows me to get the latest version of an app from it's sparkle feed instead of keeping download locations up to date
