### PR TITLE
Fix "Google Chrome.app" and other app deps with spaces in their name not working anymore

### DIFF
--- a/lib/babushka/version_of.rb
+++ b/lib/babushka/version_of.rb
@@ -10,7 +10,12 @@ module Babushka
         if rest.any?
           Babushka::VersionOf.new(*[first].concat(rest))
         elsif first.is_a?(String)
-          Babushka::VersionOf.new(*first.split(' ', 2))
+          name, version = first.split(' ', 2)
+          if version && VersionStr.valid?(version)
+            Babushka::VersionOf.new(name, version)
+          else
+            Babushka::VersionOf.new(first)
+          end
         elsif first.is_a?(Array)
           Babushka::VersionOf.new(*first)
         else

--- a/lib/babushka/version_str.rb
+++ b/lib/babushka/version_str.rb
@@ -8,6 +8,14 @@ module Babushka
     attr_reader :pieces, :operator, :version
     GemVersionOperators = %w[= == != > < >= <= ~>].freeze
 
+    def VersionStr.valid?(maybe_version_str)
+      return false if maybe_version_str.blank?
+      VersionStr.new(maybe_version_str)
+      true
+    rescue VersionStrError
+      false
+    end
+
     def <=> other
       other = other.to_version unless other.is_a? VersionStr
       max_length = [pieces.length, other.pieces.length].max

--- a/spec/babushka/version_of_spec.rb
+++ b/spec/babushka/version_of_spec.rb
@@ -25,6 +25,10 @@ describe "creation" do
     version_of(version_of('ruby', '1.8')).should == version_of('ruby', '1.8')
     version_of(version_of('ruby', '1.8'), '1.9').should == version_of('ruby', '1.9')
   end
+  it "should accept name with space" do
+    version_of('Google Chrome.app').name.should == 'Google Chrome.app'
+    version_of('Google Chrome.app').version.should == nil
+  end
 end
 
 describe "to_s" do

--- a/spec/babushka/version_str_spec.rb
+++ b/spec/babushka/version_str_spec.rb
@@ -70,6 +70,43 @@ describe "parsing" do
   end
 end
 
+describe 'validity' do
+  RSpec::Matchers.define :be_valid_version do
+    match do |maybe_version_str|
+      VersionStr.valid?(maybe_version_str).should be_true
+    end
+  end
+
+  it 'should detect valid version strings' do
+    [ 
+      '0.2', 
+      '0.3.10.2', 
+      '1.9.1-p243', 
+      '3.0.0.beta', 
+      '3.0.0.beta3', 
+      'R13B04', 
+      '>0.2', 
+      '>= 0.2', 
+      '~> 0.3.10.2', 
+      '= 0.2', 
+      '== 0.2', 
+      'V0.5.0',
+      '>= v.1.9.2p180'
+    ].each {|v| v.should be_valid_version }
+  end
+  it 'should detect invalid version strings' do
+    [
+      '~ 0.2',
+      '>> 0.2',
+      'nginx',
+      '0. 2',
+      '0.2!',
+      '',
+      nil
+    ].each{|v| v.should_not be_valid_version }
+  end
+end
+
 describe 'rendering' do
   it "should render just the version number with no operator" do
     VersionStr.new('0.3.1').to_s.should == '0.3.1'


### PR DESCRIPTION
see https://github.com/benhoskings/babushka/issues/176 for details

Makes "Google Chrome.app" dep work. Was failing due to there being a
space in the name, which was funking out the version string handling.

Added a .valid? class level method to VersionStr to test if a given
string is in fact a valid version. This is called by VersionOf to check
the string before passing it as a name/version.

If it doesn't contain a valid version, just pass it as a name only
without a version to the VersionOf constructor.
