### PR TITLE
Fixed test in case of babushka used through symlinked folder

### DIFF
--- a/spec/babushka/shell_helpers_spec.rb
+++ b/spec/babushka/shell_helpers_spec.rb
@@ -41,7 +41,7 @@ describe "shell" do
   context ":cd parameter" do
     before { (tmp_prefix / 'dir_param').mkdir }
     it "should run in the current directory when :cd isn't specified" do
-      shell("pwd").should == Dir.pwd
+      shell("pwd -P").should == Dir.pwd
     end
     it "should run in the specified directory" do
       shell("pwd", :cd => (tmp_prefix / 'dir_param')).should == (tmp_prefix / 'dir_param').to_s


### PR DESCRIPTION
```
$ pwd
/Users/user/proj/babushka
$ pwd -P
/Users/user/Documents/Projects/babushka
```

```
babushka@9d71f40 | ruby-1.9.3 | rspec-2.8.0

  1) shell :cd parameter should run in the current directory when :cd isn't specified
     Failure/Error: shell("pwd").should == Dir.pwd
     expected: "/Users/user/Documents/Projects/babushka"
     got: "/Users/user/proj/babushka" (using ==)
     # ./spec/babushka/shell_helpers_spec.rb:44:in `block (3 levels) in <top (required)>'

  886/886:     100% |==========================================| Time: 00:00:12

```
