### PR TITLE
Git v1.7.8.4

### DIFF
--- a/deps/git.rb
+++ b/deps/git.rb
@@ -18,7 +18,7 @@ dep 'git.managed' do
 end
 
 dep 'git.installer', :version do
-  version.default!('1.7.8.2')
+  version.default!('1.7.8.4')
   source "http://git-osx-installer.googlecode.com/files/git-#{version}-intel-universal-snow-leopard.dmg"
   provides "git >= #{version}"
   after {


### PR DESCRIPTION
Release notes:
- [1.7.8.3](https://raw.github.com/gitster/git/master/Documentation/RelNotes/1.7.8.3.txt)
- [1.7.8.4](https://raw.github.com/gitster/git/master/Documentation/RelNotes/1.7.8.4.txt)
