### PR TITLE
Patch to not break when rebar homebrew package installed

### DIFF
--- a/lib/babushka/version_str.rb
+++ b/lib/babushka/version_str.rb
@@ -9,7 +9,7 @@ module Babushka
     GemVersionOperators = %w[= == != > < >= <= ~>].freeze
 
     def self.parseable_version? str
-      !str.nil? && !str[/\d/].nil?
+      !str.nil? && !str[/\d|HEAD/].nil?
     end
 
     def initialize str

--- a/spec/babushka/version_str_spec.rb
+++ b/spec/babushka/version_str_spec.rb
@@ -9,6 +9,7 @@ describe "parsing" do
     VersionStr.new('3.0.0.beta').pieces.should == [3, 0, 0, 'beta']
     VersionStr.new('3.0.0.beta3').pieces.should == [3, 0, 0, 'beta', 3]
     VersionStr.new('R13B04').pieces.should == ['R', 13, 'B', 4]
+    VersionStr.new('HEAD').pieces.should == ['HEAD']
   end
   it "should parse the operator if supplied" do
     v = VersionStr.new('>0.2')


### PR DESCRIPTION
Dep to install rebar package with:

```
dep 'rebar.managed' do
  provides 'rebar'
end
```

Was breaking due to

```
VersionStr.new('HEAD'): couldn't parse a version number.
```

Because brew reported the version number of rebar as being `HEAD`:

```
$ brew info rebar
rebar HEAD
https://github.com/basho/rebar/wiki
Depends on: erlang
/usr/local/Cellar/rebar/HEAD (3 files, 120K)
http://github.com/mxcl/homebrew/commits/master/Library/Formula/rebar.rb
```

 Patch fixes this and allows `HEAD` as a valid version string.
