### PR TITLE
fix 'ruby.managed' for LTS Ubuntu :hardy and :lucid

### DIFF
--- a/deps/ruby.rb
+++ b/deps/ruby.rb
@@ -10,9 +10,10 @@ end
 
 dep 'ruby.managed' do
   installs {
-    via :maverick, %w[ruby ruby1.8-dev]
-    via :apt, %w[ruby ruby1.8-dev libopenssl-ruby]
-    via :yum, %w[ruby ruby-irb]
+    via :hardy, %w[ruby irb ruby1.8-dev libopenssl-ruby]
+    via :lucid, %w[ruby irb ruby1.8-dev libopenssl-ruby]
+    via :apt,   %w[ruby1.8 ruby1.8-dev libruby1.8]
+    via :yum,   %w[ruby ruby-irb]
   }
   provides %w[ruby irb]
 end

--- a/lib/babushka/system_definitions.rb
+++ b/lib/babushka/system_definitions.rb
@@ -39,7 +39,9 @@ module Babushka
             '9.10'  => :karmic,
             '10.04' => :lucid,
             '10.10' => :maverick,
-            '11.04' => :natty
+            '11.04' => :natty,
+            '11.11' => :oneiric,
+            '12.04' => :precise
           },
           :debian => {
             '4.0' => :etch,


### PR DESCRIPTION
Hi Ben,

I just found that currently ruby.managed not work on Ubuntu Server 10.04 LTS

``` console
root@ubuntu:~# dpkg -r ruby irb
dpkg: warning: ignoring request to remove ruby which isn't installed.
dpkg: warning: ignoring request to remove irb which isn't installed.

root@ubuntu:~# bash -c "`curl babushka.me/up`"
...
You don't have ruby installed, so we'll take care of that first (using aptitude).

Sound good? [y/N] y
Excellent.
...
Nice, ruby 1.8.7 was installed at /usr/bin/ruby.
######################################################################## 100.0%

babushka {
  up to date.babushka {
    repo clean.babushka {
      installed.babushka {
        Where would you like babushka installed [/usr/local/babushka]? 
        ruby {
          'irb' is missing.
          ruby.managed {
            apt {
              main.apt_source {
              } ✓ main.apt_source
              universe.apt_source {
              } ✓ universe.apt_source
              'apt-get' runs from /usr/bin.
            } ✓ apt
            ✓ system has ruby deb
            ✓ system has ruby1.8-dev deb
            ✓ system has libopenssl-ruby deb
            'irb' is missing.
            meet {
              Downloading... done.
              Installing ruby, ruby1.8-dev and libopenssl-ruby via apt... done.
            }
            ✓ system has ruby deb
            ✓ system has ruby1.8-dev deb
            ✓ system has libopenssl-ruby deb
            'irb' is missing.
          } ✗ ruby.managed
        } ✗ ruby
      } ✗ installed.babushka
    } ✗ repo clean.babushka
  } ✗ up to date.babushka
} ✗ babushka
```

with this fix ruby.managed passed

``` console
root@ubuntu:/root# babushka ruby.managed
ruby.managed {
  apt {
    main.apt_source {
    } ✓ main.apt_source
    universe.apt_source {
    } ✓ universe.apt_source
    'apt-get' runs from /usr/bin.
  } ✓ apt
  ✓ system has ruby deb
  system doesn't have irb deb
  meet {
    Downloading... done.
    Installing ruby, irb, ruby1.8-dev and libopenssl-ruby via apt... done.
  }
  ✓ system has ruby deb
  ✓ system has irb deb
  ✓ system has ruby1.8-dev deb
  ✓ system has libopenssl-ruby deb
  'ruby' & 'irb' run from /usr/bin.
} ✓ ruby.managed
```

Please pull

**upd**:
- [Ubuntu -- Package Search Results -- ruby](http://packages.ubuntu.com/search?keywords=ruby)
- [Ubuntu -- Package Search Results -- ruby1.8-dev](http://packages.ubuntu.com/search?keywords=ruby1.8-dev)
- [Ubuntu -- Package Search Results -- irb](http://packages.ubuntu.com/search?keywords=irb)
- [Ubuntu -- Package Search Results -- libopenssl-ruby](http://packages.ubuntu.com/search?keywords=libopenssl-ruby)
