### PR TITLE
Babushka::Renderable -> Use sudo to read config files if file not readable by current user

### DIFF
--- a/lib/babushka/renderable.rb
+++ b/lib/babushka/renderable.rb
@@ -58,10 +58,21 @@ module Babushka
     end
 
     def source_sha
-      File.open(path.p) {|f|
-        first_line = f.gets
-        first_line[/\A#!/] ? f.gets : first_line
-      }.scan(/, from ([0-9a-f]{40})\./).flatten.first
+      unless File.readable?(path.p)
+        lines = sudo("head -2 #{path.p}").lines.to_a
+        # if first line starts with a hash bang return second line
+        if lines.count > 1 && lines[0][/\A#!/]
+          lines[1]
+        else
+          lines.count > 0 ? lines[0] : ''
+        end
+      else
+        File.open(path.p) {|f|
+          first_line = f.gets
+          first_line[/\A#!/] ? f.gets : first_line
+        }
+      end.scan(/, from ([0-9a-f]{40})\./).flatten.first
     end
   end
 end
+


### PR DESCRIPTION
Some applications set their config files to be readable only by root (e.g. Monit). This commit checks the file permission before attempting to read the SHA1 written by Inkan. If not readable by current user it uses sudo to read the file contents
