### PR TITLE
Support options to pkg manager in managed template.

### DIFF
--- a/deps/templates/managed.rb
+++ b/deps/templates/managed.rb
@@ -40,7 +40,7 @@ managed_template = L{
     pkg_manager.update_pkg_lists_if_required
   }
   meet {
-    pkg_manager.install! packages
+    pkg_manager.install! packages, options.join(' ')
   }
 }
 
@@ -49,6 +49,7 @@ meta :managed do
   accepts_list_for :provides, :basename, :choose_with => :via
   accepts_list_for :service_name, :name
   accepts_list_for :cfg
+  accepts_list_for :options
 
   def pkg_manager
     Babushka.host.pkg_helper


### PR DESCRIPTION
For instance, when installing via brew, you sometimes want to pass options such as

```
--use-clang
```

or

```
--with-quantum-depth-8 
```

(with imagemagick)

You would use it like this:

```
dep "ffmpeg.managed" do
    options %w{--use-clang}
end
```

I'm pretty new with babushka so I'm not certain I did the correct thing. I just know that it works for me. It's an extremely small change so it's probably very easy for you to determine.

Thanks for the great work!
