### PR TITLE
Adjust Arch Linux support.

### DIFF
--- a/lib/babushka/pkg_helper.rb
+++ b/lib/babushka/pkg_helper.rb
@@ -11,7 +11,7 @@ module Babushka
     end
 
     def all_manager_keys
-      [:apt, :brew, :macports, :yum, :binpkgsrc, :binports]
+      [:apt, :pacman, :brew, :macports, :yum, :binpkgsrc, :binports]
     end
 
     def present?

--- a/lib/babushka/system_definitions.rb
+++ b/lib/babushka/system_definitions.rb
@@ -48,7 +48,8 @@ module Babushka
             '5.0' => :lenny,
             '6.0' => :squeeze,
             '7.0' => :wheezy
-          }
+          },
+          :arch => {}
         },
         :bsd => {
           :dragonfly => {},


### PR DESCRIPTION
I couldn't use 'on :arch' or 'via :pacman' choices in by deps, this commit fixes that. (I'm not sure this is the correct way of doing it, though.)
