### PR TITLE
Use official Command Line Tools for Xcode package

### DIFF
--- a/deps/dev.rb
+++ b/deps/dev.rb
@@ -13,7 +13,11 @@ end
 dep 'xcode tools', :template => 'external' do
   expects 'gcc', 'g++', 'autoconf', 'make', 'ld'
   otherwise {
-    log_and_open "Install Xcode, and then run Babushka again.", "http://developer.apple.com/technology/xcode.html"
+    log "Install Xcode, and then run Babushka again."
+    log "Official download at http://developer.apple.com/technology/xcode.html"
+    confirm "Open in browser now" do
+      shell "open http://developer.apple.com/technology/xcode.html"
+    end
   }
 end
 
@@ -24,7 +28,10 @@ dep 'xcode commandline tools', :template => 'external' do
   expects %w[make] # configure and build tools
   expects %w[cpp m4 nasm yacc bison] # misc - the preprocessor, assembler, grammar stuff
   otherwise {
-    log_and_open "Install Command Line Tools for Xcode, and then run Babushka again.",
-                 "http://developer.apple.com/downloads"
+    log "Install Command Line Tools for Xcode, and then run Babushka again."
+    log "Official pacakge at http://developer.apple.com/downloads"
+    confirm "Open in browser now" do
+      shell "open http://developer.apple.com/downloads"
+    end
   }
 end


### PR DESCRIPTION
So the supported way to do this now is to download the official package from Apple.  A small bummer because it requires user intervention to login to Apple's developer site.  However, it's guaranteed to work alongside with Xcode installs and will be supported by Apple and Homebrew.

See this post for full details http://kennethreitz.com/xcode-gcc-and-homebrew.html
