### PR TITLE
GitRepo#exists? should assert that it's actually a git repo

### DIFF
--- a/lib/babushka/git_repo.rb
+++ b/lib/babushka/git_repo.rb
@@ -58,7 +58,7 @@ module Babushka
     # nonexistent path when you initialize a GitRepo, and then call {clone!}
     # on it.
     def exists?
-      !root.nil? && root.exists?
+      !root.nil? && git_dir.exists?
     end
 
     # Run +cmd+ on the shell, changing to this repo's {root}. If the repo


### PR DESCRIPTION
This way if you're creating a path in a privileged directory in the prelude to cloning a repo in there, `GitRepo#exists?` is still a reasonable condition in a `met?` block.
