### PR TITLE
Remove ugly calls to sleep(2)

### DIFF
--- a/lib/babushka/core_patches/io.rb
+++ b/lib/babushka/core_patches/io.rb
@@ -1,8 +1,0 @@
-class IO
-  # Return true iff reading from this IO object would return data immediately,
-  # and not block while waiting for data.
-  def ready_for_read?
-    result = IO.select([self], [], [], 0)
-    result && (result.first.first == self)
-  end
-end

--- a/lib/babushka/shell.rb
+++ b/lib/babushka/shell.rb
@@ -97,23 +97,21 @@ module Babushka
     end
 
     def read_from io, buf, log_as = nil
-      while !io.closed? && io.ready_for_read?
-        output = nil
-        # Try reading less than a full line (up to just a backspace) if we're
-        # looking for progress output.
-        output = io.gets("\r") if @opts[:progress]
-        output = io.gets if output.nil?
+      output = nil
+      # Try reading less than a full line (up to just a backspace) if we're
+      # looking for progress output.
+      output = io.gets("\r") if @opts[:progress]
+      output = io.gets if output.nil?
 
-        if output.nil?
-          io.close
-        else
-          debug output.chomp, :log => @opts[:log], :as => log_as
-          buf << output
-          if @opts[:progress] && (@progress = output[@opts[:progress]])
-            print " #{@progress}#{"\b" * (@progress.length + 1)}"
-          end
-          yield if block_given?
+      if output.nil?
+        io.close
+      else
+        debug output.chomp, :log => @opts[:log], :as => log_as
+        buf << output
+        if @opts[:progress] && (@progress = output[@opts[:progress]])
+          print " #{@progress}#{"\b" * (@progress.length + 1)}"
         end
+        yield if block_given?
       end
     end
 

--- a/lib/components.rb
+++ b/lib/components.rb
@@ -14,7 +14,6 @@ module Babushka
     core_patches/hash
     core_patches/hashish
     core_patches/integer
-    core_patches/io
     core_patches/numeric
     core_patches/bytes
     core_patches/object


### PR DESCRIPTION
sleep is always a code smell. Replace it with shiny `select(2)` calls that let the kernel do something reasonable with IO on our behalf.
