### PR TITLE
Remove defaults, thereby installing latest version

### DIFF
--- a/deps/git.rb
+++ b/deps/git.rb
@@ -6,10 +6,10 @@ dep 'git', :version do
   requires_when_unmet {
     # Use the binary installer on OS X, so installing babushka
     # (which pulls in git) doesn't require a compiler.
-    on :osx, 'git.installer'.with(owner.version)
+    on :osx, 'git.installer'
     # git-1.5 can't clone https:// repos properly. Let's build
     # our own rather than monkeying with unstable debs.
-    on :lenny, 'git.src'.with(owner.version)
+    on :lenny, 'git.src'
     otherwise 'git.bin'.with(owner.version)
   }
   met? { in_path? "git >= #{version}" }


### PR DESCRIPTION
Updates #228

I hadn't pulled from upstream in a while on my fork and I was missing some changes.

This will not pass the lower version into the delegate deps, meaning it pulls the latest version from upstream.
