### PR TITLE
Instead of parsing all the remote branches, just see if one exists

### DIFF
--- a/lib/babushka/git_repo.rb
+++ b/lib/babushka/git_repo.rb
@@ -218,13 +218,8 @@ module Babushka
     # True if origin contains a branch of the same name as the current local
     # branch.
     def remote_branch_exists?
-      repo_shell('git branch -a').split("\n").map(&:strip).detect {|b|
-        # The output looks like origin/master or remotes/origin/master.
-        b[/^(remotes\/)?#{current_remote_branch}$/]
-      }
+      repo_shell?("git rev-parse refs/remotes/#{current_remote_branch}")
     end
-
-
 
     # Clone the remote at +from+ to this GitRepo's path. The path must be
     # nonexistent; an error is raised if the local repo already exists.


### PR DESCRIPTION
Another big performance win for people with lots of branches, enumerating the remote for all 1600 branches in our prod codebase takes a loooong time.
