### PR TITLE
Emit profiling information in the logs if requested.

### DIFF
--- a/lib/babushka/base.rb
+++ b/lib/babushka/base.rb
@@ -20,6 +20,11 @@ module Babushka
   class Base
   class << self
 
+    @@start_time = Time.now
+    def start_time
+      @@start_time
+    end
+
     # +task+ represents the overall job that is being run, and the parts that
     # are external to running the corresponding dep tree itself - logging, and
     # var loading and saving in particular.

--- a/lib/babushka/cmdline.rb
+++ b/lib/babushka/cmdline.rb
@@ -49,6 +49,7 @@ module Babushka
       opt '-u', '--update',       "Update referenced sources before loading deps from them"
       opt       '--show-args',    "Show the arguments being passed between deps as they're run"
       opt       '--track-blocks', "Track deps' blocks in TextMate as they're run"
+      opt       '--profile',      "Emit profiling information."
     }.run {|cmd|
       dep_names, vars = cmd.argv.partition {|arg| arg['='].nil? }
       if !(bad_var = vars.detect {|var| var[/^\w+=/].nil? }).nil?

--- a/lib/babushka/helpers/log_helpers.rb
+++ b/lib/babushka/helpers/log_helpers.rb
@@ -57,6 +57,10 @@ module Babushka
     # The message will be written to the log in the normal style, but will only
     # appear on STDOUT if debug logging is enabled.
     def debug message, opts = {}, &block
+      if Base.task.opt(:profile)
+        delta = Time.now - Base.start_time
+        message = sprintf("%.4f :: %s", delta, message)
+      end
       log message, opts.merge(:debug => !opts[:log]), &block
     end
 

--- a/spec/babushka/cmdline/help_spec.rb
+++ b/spec/babushka/cmdline/help_spec.rb
@@ -52,6 +52,7 @@ describe "help" do
     -u, --update                     Update referenced sources before loading deps from them
         --show-args                  Show the arguments being passed between deps as they're run
         --track-blocks               Track deps' blocks in TextMate as they're run
+        --profile                    Emit profiling information.
 ")
 
       Cmdline.should_receive(:log).with("\n")


### PR DESCRIPTION
Stashing the start time in a classvariable on Base isn't ideal but it
seems like a reasonable place to stick something that needs to be
globally accessible
