### PR TITLE
Case-insensitive regex to detect Location header

### DIFF
--- a/lib/babushka/resource.rb
+++ b/lib/babushka/resource.rb
@@ -37,7 +37,7 @@ module Babushka
         response_code = result.val_for(/HTTP\/1\.\d/) # not present for ftp://, etc.
         if response_code && response_code[/^[23]/].nil?
           log_error "Couldn't download #{url}: #{response_code}."
-        elsif !(location = result.val_for('Location')).nil?
+        elsif !(location = result.val_for(/^location:/i)).nil?
           log "Following redirect from #{url}"
           download URI.escape(location), location.p.basename
         else


### PR DESCRIPTION
The Resource class follows `Location:` headers when fetching resources using `curl`. The location header is detected manually using `.val_for('Location')`, however according to [RFC 2616](http://tools.ietf.org/html/rfc2616#section-4.2), the field names for HTTP message headers should be case-insensitive.

This pull request changes the string `'Location'` to the regex `/^location:/i`, which should match all valid permutations of case for this header.

I discovered this when I noticed that Dropbox use `location` (all lowercase) to redirect to the latest version of their client software, as you can see by running the following command:

``` bash
curl -I 'https://www.dropbox.com/download?plat=mac'
```

@richo told me I should provide a spec for any pull requests but I couldn't see any existing tests for this class. This is also my first public pull request _ever_ and I'm not really a Ruby programmer, but I'm learning! If tests are really required, some examples or advice would be really appreciated.
