### PR TITLE
Allow extracting DmgAssets with EULAs

### DIFF
--- a/lib/babushka/asset.rb
+++ b/lib/babushka/asset.rb
@@ -118,7 +118,7 @@ module Babushka
   class DmgAsset < Asset
     def extract &block
       in_download_dir {
-        output = log_shell "Attaching #{filename}", "hdiutil attach '#{filename.p.basename}'"
+        output = log_shell "Attaching #{filename}", "hdiutil attach '#{filename.p.basename}'", :input => "y"
         if output.nil?
           log_error "Couldn't mount #{filename.p}."
         elsif (path = mountpoint_for(output)).nil?


### PR DESCRIPTION
A DMG image can have an End User Licence Agreement (EULA) attached to it. When mounted, the user is required to accept the EULA before it will be mounted. 

When using `hdiutil attach` from the command-line to mount a DMG file, the licence agreement is shown in the terminal using the user's `PAGER`, then a prompt asks the user to confirm their acceptance before the image is mounted. The DmgAsset class uses `hdiutil` but doesn't connect stdin or stdout, so it won't mount the image. 

This change pipes a single `y` character and a newline into `hdiutil` to indicate acceptance of the EULA, allowing the image to be mounted.
