### PR TITLE
Make extra_source parameter of src.met work again

### DIFF
--- a/deps/templates/src.rb
+++ b/deps/templates/src.rb
@@ -38,12 +38,15 @@ meta :src do
     met? { in_path?(provides) }
     meet {
       extra_source.each {|uri|
-        Babushka::Resource.extract(uri)
+        Babushka::Resource.extract(uri, true)
       }
       source.each {|uri|
         Babushka::Resource.extract(uri) {|archive|
           invoke(:process_source)
         }
+      }
+      extra_source.each {|uri|
+        Babushka::Resource.extract(uri)
       }
     }
   }

--- a/lib/babushka/asset.rb
+++ b/lib/babushka/asset.rb
@@ -44,11 +44,11 @@ module Babushka
       !type.nil?
     end
 
-    def extract &block
-      cd(build_prefix, :create => true) { process_extract(&block) }
+    def extract defer_cleanup=false, &block
+      cd(build_prefix, :create => true) { process_extract(defer_cleanup, &block) }
     end
 
-    def process_extract &block
+    def process_extract defer_cleanup=false, &block
       shell("mkdir -p '#{name}'") and
       cd(name) {
         unless ShellHelpers.log_shell("Extracting #{filename}", extract_command)
@@ -61,7 +61,8 @@ module Babushka
       }.tap {|result|
         if result
           LogHelpers.log_block "Cleaning up" do
-            (build_prefix / name).p.rm
+            return true if defer_cleanup
+            (build_prefix / name).p.rm unless defer_cleanup
           end
         else
           LogHelpers.log "The build artefacts are in #{build_prefix / name / content_subdir}."

--- a/lib/babushka/resource.rb
+++ b/lib/babushka/resource.rb
@@ -19,10 +19,10 @@ module Babushka
       end
     end
 
-    def self.extract url, &block
+    def self.extract url, defer_cleanup=false, &block
       get url do |download_path|
         in_build_dir {
-          Asset.for(download_path).extract(&block)
+          Asset.for(download_path).extract(defer_cleanup, &block)
         }
       end
     end


### PR DESCRIPTION
The adds a parameter called defer_cleanup (default false) to the extract functions in Resource and Asset.

Src.meta then just re-processes the extra sources afterwards without the defer-cleanup. This is a little bit sloppy – but I don't understand the code quite well enough to just cleanup without going through the extract process again.
