### PR TITLE
Explicitly depend pip on python.bin

### DIFF
--- a/deps/pkg_managers.rb
+++ b/deps/pkg_managers.rb
@@ -40,7 +40,7 @@ end
 dep 'pip' do
   requires {
     on :brew, 'python.bin' # homebrew installs pip along with python.
-    otherwise 'pip.bin'
+    otherwise 'python.bin', 'pip.bin'
   }
 end
 


### PR DESCRIPTION
Otherwise, trying to install pip binaries explodes with a confusing
python-config error, as pip doesn't directly depend on python-dev on
ubuntu.
