### PR TITLE
Reformat 'admins can sudo' dep appropriately so it does not fail with deprecated #append

### DIFF
--- a/deps/system.rb
+++ b/deps/system.rb
@@ -1,7 +1,7 @@
 dep 'admins can sudo' do
   requires 'admin group', 'sudo.bin'
   met? { !sudo('cat /etc/sudoers').split("\n").grep(/^%admin/).empty? }
-  meet { append_to_file '%admin  ALL=(ALL) ALL', '/etc/sudoers', :sudo => true }
+  meet { '/etc/sudoers'.p.append("%admin  ALL=(ALL) ALL") }
 end
 
 dep 'admin group' do


### PR DESCRIPTION
After installing and running `babushka babushka` on an updated Debain squeeze stable, I receive the following error:

> admins can sudo {
>  admin group {
>  } â admin group
> sudo.bin {
>    'sudo' runs from /usr/bin.
>  } â sudo.bin
>  meet {
>    /usr/local/babushka/lib/babushka/helpers/log_helpers.rb:78:in `removed!': >#append_to_file has been removed after being deprecated. Use Fancypath#append >instead, e.g.:
>    '/etc/sudoers'.p.append("%admin  ALL=(ALL) ALL")
>    Check /usr/local/babushka/deps/system.rb:4.
>  } â admins can sudo
>  You can view a more detailed log at '/home/username/.babushka/logs/admins can sudo'.

It appears the code for this base dep needs to be updated.  Will send a pull request when I have a minute.

I know this is a simple pull, but I just started using babushka after a long time and not very good with Ruby.  A small hiccup but this dep is often mentioned in docs so it would help if it was working on current babushka.
