### PR TITLE
Fix 'babushka edit' command, when no EDITOR/BABUSHKA_EDITOR/VISUAL env set

### DIFF
--- a/lib/babushka/cmdline.rb
+++ b/lib/babushka/cmdline.rb
@@ -103,7 +103,7 @@ module Babushka
             log_error "Can't edit '#{dep.name}', since it wasn't loaded from a file."
           else
             file, line = dep.context.source_location
-            editor_var = ENV['BABUSHKA_EDITOR'] || ENV['VISUAL'] || ENV['EDITOR'] || which('subl') || which('mate') || which('vim') || which('vi')
+            editor_var = ENV['BABUSHKA_EDITOR'] || ENV['VISUAL'] || ENV['EDITOR'] || ShellHelpers.which('subl') || ShellHelpers.which('mate') || ShellHelpers.which('vim') || ShellHelpers.which('vi')
             case editor_var
             when /^subl/
               exec "subl -n '#{file}':#{line}"


### PR DESCRIPTION
Without this fix:

$ babushka edit npm
/usr/local/babushka/lib/babushka/cmdline.rb:106: undefined method `which' for Babushka::Cmdline:Class (NoMethodError)
    from /usr/local/babushka/lib/babushka/source_pool.rb:68:in`call'
    from /usr/local/babushka/lib/babushka/source_pool.rb:68:in `find_or_suggest'
    from /usr/local/babushka/lib/babushka/cmdline.rb:101
    from /usr/local/babushka/lib/babushka/cmdline/parser.rb:28:in`call'
    from /usr/local/babushka/lib/babushka/cmdline/parser.rb:28:in `run'
    from /usr/local/babushka/lib/babushka/base.rb:60:in`run'
    from /usr/local/bin/babushka:25
