### PR TITLE
Removing llvm references in xcode tools

### DIFF
--- a/deps/dev.rb
+++ b/deps/dev.rb
@@ -15,7 +15,7 @@ dep 'linux build tools', :template => 'bin' do
 end
 
 dep 'xcode tools', :template => 'external' do
-  expects %w[cc gcc c++ g++ llvm-gcc llvm-g++ clang make ld libtool]
+  expects %w[cc gcc c++ g++ clang make ld libtool]
   otherwise {
     unmeetable! "Install Xcode via the App Store, then go Preferences -> Downloads -> Components -> Command Line Tools."
   }


### PR DESCRIPTION
They're no longer supported in XCode 5: https://developer.apple.com/library/ios/documentation/DeveloperTools/Conceptual/WhatsNewXcode/Articles/xcode_5_0.html
