### PR TITLE
Add Debian 7.2 / wheezy codename support.

### DIFF
--- a/lib/babushka/system_definition.rb
+++ b/lib/babushka/system_definition.rb
@@ -72,7 +72,8 @@ module Babushka
           '5.0' => :lenny,
           '6.0' => :squeeze,
           '7.0' => :wheezy,
-          '7.1' => :wheezy, # Temporary, until these are parsed by major version.
+          '7.1' => :wheezy, # Temporary, until these are parsed by major
+          '7.2' => :wheezy, # version.
           '8.0' => :jessie
         },
         :redhat => {


### PR DESCRIPTION
Signed-off-by: Laurent Vallar val@zbla.net

Updated Debian 7: 7.2 released, cf. http://www.debian.org/News/2013/20131012
