### PR TITLE
Avoid uninitialized constant Babushka::GitFS::Base exception

### DIFF
--- a/lib/babushka/git_fs.rb
+++ b/lib/babushka/git_fs.rb
@@ -1,30 +1,32 @@
+module Babushka
+  class GitFS
 
-class Babushka::GitFS
+    GITIGNORE_FILE = (Babushka::Path.path / 'conf/git_fs_gitignore')
 
-  GITIGNORE_FILE = (Babushka::Path.path / 'conf/git_fs_gitignore')
-
-  def self.snapshotting_with message, &blk
-    if Base.task.opt(:git_fs)
-      init
-      blk.call.tap {|result| commit(message) if result }
-    else
-      blk.call
+    def self.snapshotting_with message, &blk
+      if Base.task.opt(:git_fs)
+        init
+        blk.call.tap {|result| commit(message) if result }
+      else
+        blk.call
+      end
     end
-  end
 
-  def self.commit message
-    repo.repo_shell('git add -A .')
-    repo.commit!(message)
-  end
-
-  def self.init
-    unless repo.exists?
-      repo.init!(File.read(GITIGNORE_FILE))
-      commit("Add the base system.")
+    def self.commit message
+      repo.repo_shell('git add -A .')
+      repo.commit!(message)
     end
-  end
 
-  def self.repo
-    @repo ||= Babushka::GitRepo.new('/')
+    def self.init
+      unless repo.exists?
+        repo.init!(File.read(GITIGNORE_FILE))
+        commit("Add the base system.")
+      end
+    end
+
+    def self.repo
+      @repo ||= Babushka::GitRepo.new('/')
+    end
+
   end
 end


### PR DESCRIPTION
Since last release v0.17.5 I get this error :

```
vagrant@guest:~$ sudo babushka --debug --update --defaults --colour 'apt source' uri='http://http.debian.net/debian' release='wheezy' repo='main contrib non-free'
$ git rev-parse --git-dir
/usr/local/babushka/.git
Defining core:external template
Defining core:src template
Defining core:app template
Defining core:bin template
Defining core:tmbundle template
Defining core:managed template
Defining core:gem template
Defining core:pip template
Defining core:npm template
Defining core:task template
Defining core:lib template
Defining core:installer template
Defining core:fhs template
Defining core:babushka template
Defining core:homebrew template
Defining core:release template
Loaded 52 deps from /usr/local/babushka/deps.
$ git rev-parse --git-dir
fatal: Not a git repository (or any parent up to mount point /home/vagrant/babushka-deps)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
$ git rev-parse --git-dir
fatal: Not a git repository (or any parent up to mount point /home/vagrant/babushka-deps)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
Loaded 45 deps from /home/vagrant/babushka-deps.
$ git rev-parse --git-dir
.git
$ git config remote.origin.url
gitolite@git.xilopix.net:babushka-deps
Loaded 76 deps from /root/.babushka/deps.
$ git rev-parse --git-dir
.git
$ git rev-parse --short HEAD
5d5b518
babushka@5d5b518 | /usr/bin/ruby@1.9.3-p194
apt source(uri: "http://http.debian.net/debian", release: "wheezy", repo: "main contrib non-free") {
  (defining apt source against Babushka::BaseTemplate from /usr/local/babushka/deps/apt.rb)
  $ uname -s
  Linux
  setup not defined.
  $ grep -R -h \^deb /etc/apt/sources.list /etc/apt/sources.list.d/
  deb http://cdn.debian.net/debian wheezy main
  /usr/local/babushka/lib/babushka/git_fs.rb:6:in `snapshotting_with': uninitialized constant Babushka::GitFS::Base
  /usr/local/babushka/lib/babushka/git_fs.rb:6:in `snapshotting_with'
  /usr/local/babushka/lib/babushka/dep.rb:323:in `run_met'
  /usr/local/babushka/lib/babushka/dep.rb:313:in `run_met_stage'
  /usr/local/babushka/lib/babushka/dep.rb:293:in `block in process!'
  /usr/local/babushka/lib/babushka/helpers/log_helpers.rb:115:in `log'
  /usr/local/babushka/lib/babushka/dep.rb:284:in `process!'
  /usr/local/babushka/lib/babushka/dep.rb:269:in `block in process_with_caching'
  /usr/local/babushka/lib/babushka/dep_cache.rb:14:in `call'
  /usr/local/babushka/lib/babushka/dep_cache.rb:14:in `read'
  /usr/local/babushka/lib/babushka/dep.rb:266:in `process_with_caching'
  /usr/local/babushka/lib/babushka/dep.rb:211:in `process_as_requirement'
  /usr/local/babushka/lib/babushka/dep.rb:198:in `process'
  /usr/local/babushka/lib/babushka/task.rb:34:in `block (2 levels) in process_dep'
  /usr/local/babushka/lib/babushka/task.rb:79:in `with_logging'
  /usr/local/babushka/lib/babushka/task.rb:33:in `block in process_dep'
  /usr/local/babushka/lib/babushka/source_pool.rb:68:in `call'
  /usr/local/babushka/lib/babushka/source_pool.rb:68:in `find_or_suggest'
  /usr/local/babushka/lib/babushka/task.rb:31:in `process_dep'
  /usr/local/babushka/lib/babushka/task.rb:23:in `block in process'
  /usr/local/babushka/lib/babushka/task.rb:23:in `each'
  /usr/local/babushka/lib/babushka/task.rb:23:in `all?'
  /usr/local/babushka/lib/babushka/task.rb:23:in `process'
  /usr/local/babushka/lib/babushka/cmdline.rb:65:in `block in <class:Cmdline>'
  /usr/local/babushka/lib/babushka/cmdline/parser.rb:28:in `call'
  /usr/local/babushka/lib/babushka/cmdline/parser.rb:28:in `run'
  /usr/local/babushka/lib/babushka/base.rb:61:in `run'
  /usr/local/bin/babushka:25:in `<main>'
  Check /usr/local/babushka/deps/apt.rb.
  You can view the log at '/root/.babushka/logs/apt source'.
vagrant@gitlab:~$ cat '/root/.babushka/logs/apt source'
cat: /root/.babushka/logs/apt source: Permission non accordée
vagrant@gitlab:~$ sudo cat '/root/.babushka/logs/apt source'
$ git rev-parse --git-dir
.git
$ git rev-parse --short HEAD
5d5b518
babushka@5d5b518 | /usr/bin/ruby@1.9.3-p194
apt source(uri: "http://http.debian.net/debian", release: "wheezy", repo: "main contrib non-free") {
  (defining apt source against Babushka::BaseTemplate from /usr/local/babushka/deps/apt.rb)
  $ uname -s
  Linux
  setup not defined.
  $ grep -R -h \^deb /etc/apt/sources.list /etc/apt/sources.list.d/
  deb http://cdn.debian.net/debian wheezy main
  /usr/local/babushka/lib/babushka/git_fs.rb:6:in `snapshotting_with': uninitialized constant Babushka::GitFS::Base
  /usr/local/babushka/lib/babushka/git_fs.rb:6:in `snapshotting_with'
  /usr/local/babushka/lib/babushka/dep.rb:323:in `run_met'
  /usr/local/babushka/lib/babushka/dep.rb:313:in `run_met_stage'
  /usr/local/babushka/lib/babushka/dep.rb:293:in `block in process!'
  /usr/local/babushka/lib/babushka/helpers/log_helpers.rb:115:in `log'
  /usr/local/babushka/lib/babushka/dep.rb:284:in `process!'
  /usr/local/babushka/lib/babushka/dep.rb:269:in `block in process_with_caching'
  /usr/local/babushka/lib/babushka/dep_cache.rb:14:in `call'
  /usr/local/babushka/lib/babushka/dep_cache.rb:14:in `read'
  /usr/local/babushka/lib/babushka/dep.rb:266:in `process_with_caching'
  /usr/local/babushka/lib/babushka/dep.rb:211:in `process_as_requirement'
  /usr/local/babushka/lib/babushka/dep.rb:198:in `process'
  /usr/local/babushka/lib/babushka/task.rb:34:in `block (2 levels) in process_dep'
  /usr/local/babushka/lib/babushka/task.rb:79:in `with_logging'
  /usr/local/babushka/lib/babushka/task.rb:33:in `block in process_dep'
  /usr/local/babushka/lib/babushka/source_pool.rb:68:in `call'
  /usr/local/babushka/lib/babushka/source_pool.rb:68:in `find_or_suggest'
  /usr/local/babushka/lib/babushka/task.rb:31:in `process_dep'
  /usr/local/babushka/lib/babushka/task.rb:23:in `block in process'
  /usr/local/babushka/lib/babushka/task.rb:23:in `each'
  /usr/local/babushka/lib/babushka/task.rb:23:in `all?'
  /usr/local/babushka/lib/babushka/task.rb:23:in `process'
  /usr/local/babushka/lib/babushka/cmdline.rb:65:in `block in <class:Cmdline>'
  /usr/local/babushka/lib/babushka/cmdline/parser.rb:28:in `call'
  /usr/local/babushka/lib/babushka/cmdline/parser.rb:28:in `run'
  /usr/local/babushka/lib/babushka/base.rb:61:in `run'
  /usr/local/bin/babushka:25:in `<main>'
  Check /usr/local/babushka/deps/apt.rb.
  You can view the log at '/root/.babushka/logs/apt source'.
```

Defining **GitFS**'s class inside **Babushka**'s module should fix this issue, plus code re-indentation...

Signed-off-by: Laurent Vallar val@zbla.net
