### PR TITLE
work around noisy 'conflicting chdir during another chdir block' warnings

### DIFF
--- a/lib/babushka/popen.rb
+++ b/lib/babushka/popen.rb
@@ -13,10 +13,12 @@ module Babushka
         reopen_pipe_for :write, pipe_out, STDOUT
         reopen_pipe_for :write, pipe_err, STDERR
 
-        Dir.chdir opts[:chdir] if opts[:chdir]
         ENV.update opts[:env] if opts[:env]
-
-        exec(*cmd)
+        if opts[:chdir]
+          Dir.chdir(opts[:chdir]) { exec(*cmd) }
+        else
+          exec(*cmd)
+        end
       }
 
       near.each {|p| p.sync = true }


### PR DESCRIPTION
If the popen method is used with the :chdir option within a Dir.chdir
block on ruby 1.9 (fex inside a in_build_dir block), a warning is issued that is needless distraction here
since we're about to exec anyway.

See the implementation of Dir.chdir
http://www.ruby-doc.org/core-1.9.3/Dir.html#method-c-chdir
