### PR TITLE
Allow homebrew to install tapped packages.

### DIFF
--- a/lib/babushka/pkg_helpers/brew_helper.rb
+++ b/lib/babushka/pkg_helpers/brew_helper.rb
@@ -44,17 +44,20 @@ module Babushka
     def check_for_formulas pkgs
       pkgs.all? {|pkg|
         has_formula_for?(pkg).tap {|result|
-          log_error "There is no formula for '#{pkg}' in #{formulas_path}." unless result
+          log_error "There is no formula for '#{pkg}' in #{formulas_path} nor #{taps_path}." unless result
         }
       }
     end
 
     def has_formula_for? pkg
-      existing_formulas.include? pkg.name
+      # Tapped formulas need to be mapped to a path
+      # e.g. homebrew/dupes/redis.rb => 'homebrew-dupes/**/redis.rb'
+      formula = pkg.name.sub('/', '-').sub('/', '/(.*/)?') + '.rb\Z'
+      existing_formulas.any? {|path| path.match /#{formula}/ }
     end
 
     def existing_formulas
-      Dir[formulas_path / '*.rb'].map {|i| File.basename i, '.rb' }
+      Dir[formulas_path / '*.rb', taps_path / '**/*.rb']
     end
 
     def active_version_of pkg
@@ -90,6 +93,10 @@ module Babushka
 
     def formulas_path
       prefix / 'Library/Formula'
+    end
+
+    def taps_path
+      prefix / 'Library/Taps'
     end
 
     def homebrew_lib_path

--- a/spec/babushka/brew_helper_spec.rb
+++ b/spec/babushka/brew_helper_spec.rb
@@ -62,4 +62,24 @@ From: https://github.com/mxcl/homebrew/commits/master/Library/Formula/readline.r
       ]
     end
   end
+
+  describe '#has_formula_for?' do
+    before {
+      brew_helper.stub(:prefix).and_return('/usr/local')
+      Dir.stub(:[]).with('/usr/local/Library/Formula/*.rb', '/usr/local/Library/Taps/**/*.rb').and_return([
+        '/usr/local/Library/Formula/zsh.rb',
+        '/usr/local/Library/Taps/homebrew-dupes/apple-gcc42.rb',
+        '/usr/local/Library/Taps/original-dev/Formula/redis.rb',
+      ])
+    }
+    it "should find both core and tapped packages" do
+      zsh = double('pkg', :name => 'zsh')
+      gcc42 = double('pkg', :name => 'homebrew/dupes/apple-gcc42')
+      redis = double('pkg', :name => 'original/dev/redis')
+
+      brew_helper.send(:has_formula_for?, zsh).should be_true
+      brew_helper.send(:has_formula_for?, gcc42).should be_true
+      brew_helper.send(:has_formula_for?, redis).should be_true
+    end
+  end
 end


### PR DESCRIPTION
Homebrew has the concept of "taps": repositories with custom formulas.
These formulas live in /usr/local/Library/Taps, instead of the
usual /usr/local/Library/Formula.

This commit checks for the presence of tapped formulas, to allow for:

``` ruby
  # Without this commit, babushka would be unable to find and install this package
  dep do "apple-gcc42", :template => "bin" do
    requires "homebrew-dupes.tap"
    installs "homebrew/dupes/apple-gcc42"
  end
```

Note taps still need to be installed before babushka will find
them:

``` ruby
  dep "homebrew-dupes.tap" do
    requires "homebrew"

    TAPS_DIR = "/usr/local/Library/Taps"

    met? do
      "#{TAPS_DIR}/homebrew-dupes".p.exists?
    end

    meet do
      shell "mkdir -p #{TAPS_DIR}"
      log_shell "Brewing Homebrew Dupes tap", "homebrew tap
  homebrew/dupes"
    end
  end
```
