### PR TITLE
accepts_value_for(:do_cleanup, false) does not setup value to be false

### DIFF
--- a/spec/babushka/accepts_for_spec.rb
+++ b/spec/babushka/accepts_for_spec.rb
@@ -81,6 +81,10 @@ describe "accepts_*_for" do
       subject.produces.should == ["a default response"]
       subject.valid_formats.should == %w[html xml js json]
     end
+    it "should return the correct boolean default when no value is stored" do
+      subject.do_cleanup.should == [false]
+      subject.do_backup.should == [true]
+    end
     it "should accept splatted args" do
       subject.records "an item", "another item"
       subject.records.should == ["an item", "another item"]

--- a/spec/babushka/accepts_for_support.rb
+++ b/spec/babushka/accepts_for_support.rb
@@ -28,6 +28,8 @@ class AcceptsForTest
   accepts_value_for :package, :choose_with => :via
   accepts_value_for :renders, "a default response", :choose_with => :via
   accepts_value_for :format, :default_format, :choose_with => :via
+  accepts_value_for :do_cleanup, false, :choose_with => :via
+  accepts_value_for :do_backup, true, :choose_with => :via
 
   accepts_list_for :records, :choose_with => :via
   accepts_list_for :produces, "a default response", :choose_with => :via
@@ -38,6 +40,8 @@ def test_lists
   {
     nil         => [],
     []          => [],
+    true        => [true],
+    false       => [false],
     'a'         => ['a'],
     %w[a]       => ['a'],
     %w[a b c]   => ['a', 'b', 'c']


### PR DESCRIPTION
Hello Ben,

is it expected behavior? :)

``` ruby
babushka@8311af7 | ruby-1.9.3p448 | rspec-2.14.1
  1) accepts_*_for accepts_list_for should return the correct boolean default when no value is stored
     Failure/Error: subject.do_cleanup.should == [false]
       expected: [false]
            got: nil (using ==)
     # ./spec/babushka/accepts_for_spec.rb:85:in `block (3 levels) in <top (required)>'

 1098/1098 |========================================================================= 100 =========================================================================>| Time: 00:00:34 

Finished in 34.96 seconds
1098 examples, 1 failure
```
