### PR TITLE
Add Debian 7.3 / wheezy codename support.

### DIFF
--- a/lib/babushka/system_definition.rb
+++ b/lib/babushka/system_definition.rb
@@ -74,6 +74,7 @@ module Babushka
           '7.0' => :wheezy,
           '7.1' => :wheezy, # Temporary, until these are parsed by major
           '7.2' => :wheezy, # version.
+          '7.3' => :wheezy,
           '8.0' => :jessie
         },
         :redhat => {


### PR DESCRIPTION
Signed-off-by: Laurent Vallar val@zbla.net

Updated Debian 7.3 (wheezy) has been released, see http://www.debian.org/News/2013/20131214
