### PR TITLE
Adding PPA's fails if not being run as root

### DIFF
--- a/deps/apt.rb
+++ b/deps/apt.rb
@@ -46,8 +46,8 @@ dep 'ppa', :spec do
     ('/var/lib/apt/lists/' / ppa_release_file).exists?
   }
   meet {
-    log_shell "Adding #{spec}", "add-apt-repository '#{spec}'", :spinner => true
-    log_shell "Updating apt lists to load #{spec}.", "apt-get update"
+    log_shell "Adding #{spec}", "add-apt-repository '#{spec}'", :spinner => true, :sudo => true
+    log_shell "Updating apt lists to load #{spec}.", "apt-get update", :sudo => true
   }
 end
 


### PR DESCRIPTION
Previously

```
Stderr from the command:

            Error: must run as root
 failed
            E: Could not open lock file /var/lib/apt/lists/lock - open (13: Permission denied)
            E: Unable to lock directory /var/lib/apt/lists/
            E: Could not open lock file /var/lib/dpkg/lock - open (13: Permission denied)
            E: Unable to lock the administration directory (/var/lib/dpkg/), are you root?
 failed
```

relevant dep

``` ruby
dep "tmux.managed" do
  requires "ppa".with("ppa:pi-rho/dev")
  installs "tmux"
  provides "tmux"
end
```
