### PR TITLE
Update NPM installation script URL

### DIFF
--- a/deps/pkg_managers.rb
+++ b/deps/pkg_managers.rb
@@ -29,7 +29,7 @@ dep 'npm.src' do
   requires 'nodejs.bin'
   met? { which 'npm' }
   meet {
-    log_shell "Installing npm", "curl https://npmjs.org/install.sh | #{'sudo' unless which('node').p.writable_real?} sh"
+    log_shell "Installing npm", "curl https://www.npmjs.org/install.sh | #{'sudo' unless which('node').p.writable_real?} sh"
   }
 end
 


### PR DESCRIPTION
Currently `curl https://npmjs.org/install.sh` returns a redirection page.

The resource evidently keeps moving around... following the redirect with `curl -L` might be another option.
