### PR TITLE
Adding apt source repo fixes

### DIFF
--- a/deps/apt.rb
+++ b/deps/apt.rb
@@ -2,7 +2,8 @@ dep 'keyed apt source', :uri, :release, :repo, :key_sig, :key_uri do
   requires 'apt source'.with(uri, release, repo, uri, 'no')
 
   met? {
-    shell('apt-key list').split("\n").collapse(/^pub.*\//).val_for(key_sig)
+    shell?('apt-key list', :sudo => true) &&
+    shell('apt-key list', :sudo => true).split("\n").collapse(/^pub.*\//).val_for(key_sig)
   }
   meet {
     key = log_shell("Downloading #{key_uri}", 'curl', key_uri)

--- a/deps/apt.rb
+++ b/deps/apt.rb
@@ -26,7 +26,7 @@ dep 'apt source', :uri, :release, :repo, :uri_matcher, :should_update do
   }
   meet {
     log_block "Adding #{release} from #{uri}" do
-      '/etc/apt/sources.list.d/babushka.list'.p.append("deb #{uri} #{release} #{repo}\n")
+      sudo "echo \"deb #{uri} #{release} #{repo}\n\" >> /etc/apt/sources.list.d/babushka.list" 
     end
 
     Babushka::AptHelper.update_pkg_lists "Updating apt lists to load #{uri}." if should_update[/^y/]

--- a/deps/apt.rb
+++ b/deps/apt.rb
@@ -7,7 +7,7 @@ dep 'keyed apt source', :uri, :release, :repo, :key_sig, :key_uri do
   }
   meet {
     key = log_shell("Downloading #{key_uri}", 'curl', key_uri)
-    log_shell("Adding #{key_sig}", 'apt-key add -', :input => key)
+    log_shell("Adding #{key_sig}", 'apt-key add -', :input => key, :sudo => true)
     Babushka::AptHelper.update_pkg_lists "Updating apt lists to load #{uri}"
   }
 end


### PR DESCRIPTION
When running as non-root user, adding apt sources was failing. This PR addresses adding a new key to the apt keyring, and makes sure it can append to the sources.list file.

There might be a nicer way of adding to the sources list that still uses FancyPath, welcome to adjust, but the following works.