### PR TITLE
ShellHelpers cmd_dir should not return directories that match cmd_name

### DIFF
--- a/lib/babushka/helpers/shell_helpers.rb
+++ b/lib/babushka/helpers/shell_helpers.rb
@@ -188,7 +188,8 @@ module Babushka
     # also faster to not shell out.
     def cmd_dir cmd_name
       ENV['PATH'].split(':').detect {|path|
-        File.executable? File.join(path, cmd_name.to_s)
+        full_path = File.join(path, cmd_name.to_s)
+        File.executable?(full_path) && File.file?(full_path)
       }
     end
 

--- a/spec/babushka/shell_helpers_spec.rb
+++ b/spec/babushka/shell_helpers_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'tmpdir'
 
 SUCCEEDING_LS = 'ls /bin'
 FAILING_LS = 'ls /missing'
@@ -276,6 +277,18 @@ describe "which" do
   it "should handle command parameter passed as Symbol" do
     path = `which ls`.chomp
     Babushka::ShellHelpers.which(:ls).should == path
+  end
+  it "should not return a directory" do
+    original_env = ENV['PATH']
+    begin
+      Dir.mktmpdir do |dir|
+        Dir.mkdir(File.join(dir, 'directorycmd'), 0700)
+        ENV['PATH'] = "#{ENV['PATH']}:#{dir}"
+        Babushka::ShellHelpers.which('directorycmd').should be_nil
+      end
+    ensure
+      ENV['PATH'] = original_env
+    end
   end
 end
 


### PR DESCRIPTION
This failed for us when we had a directory named 'brew' that happened to be in the path. 
