### PR TITLE
Sort glob output so that it is consistent

### DIFF
--- a/lib/babushka/source.rb
+++ b/lib/babushka/source.rb
@@ -139,7 +139,7 @@ module Babushka
 
     def load_deps!
       unless @loaded
-        path.p.glob('**/*.rb').each {|f|
+        path.p.glob('**/*.rb').sort.each {|f|
           Base.sources.load_context :source => self, :path => f do
             load f
           end


### PR DESCRIPTION
We depend on sorted order of deps since we have a huge repository and we started refactoring our deps to make them modular.

Unsorted glob o/p breaks load order and makes us sad.