### PR TITLE
Raspbian support

### DIFF
--- a/lib/babushka/pkg_helpers/apt_helper.rb
+++ b/lib/babushka/pkg_helpers/apt_helper.rb
@@ -22,14 +22,16 @@ module Babushka
     def source_for_system
       {
         :debian => 'http://http.debian.net/debian',
-        :ubuntu => 'http://archive.ubuntu.com/ubuntu'
+        :ubuntu => 'http://archive.ubuntu.com/ubuntu',
+        :raspbian => 'http://archive.raspbian.org/raspbian',
       }[Babushka.host.flavour]
     end
 
     def source_matcher_for_system
       {
         :debian => %r{http://(ftp\d?\.(\w\w\.)?debian\.org|(http|cdn)\.debian\.net)/debian/?},
-        :ubuntu => %r{http://((\w\w-(.*)-\d\.ec2\.)|(\w\w\.))?archive\.ubuntu\.com/ubuntu/?}
+        :ubuntu => %r{http://((\w\w-(.*)-\d\.ec2\.)|(\w\w\.))?archive\.ubuntu\.com/ubuntu/?},
+        :raspbian => %r{http://(archive|mirrordirector)\.raspbian\.org/raspbian/?},
       }[Babushka.host.flavour]
     end
 

--- a/lib/babushka/system_detector.rb
+++ b/lib/babushka/system_detector.rb
@@ -17,11 +17,7 @@ module Babushka
 
     def self.detect_using_release_file
       if File.exists?('/etc/debian_version')
-        if File.exists?('/etc/lsb-release') && File.read('/etc/lsb-release')[/ubuntu/i]
-          UbuntuSystemProfile
-        else
-          DebianSystemProfile
-        end
+        detect_debian_derivative
       elsif File.exists?('/etc/arch-release')
         ArchSystemProfile
       elsif File.exists?('/etc/fedora-release')
@@ -34,5 +30,16 @@ module Babushka
         SuseSystemProfile
       end
     end
+
+    def self.detect_debian_derivative
+      if File.exists?('/etc/lsb-release') && File.read('/etc/lsb-release')[/ubuntu/i]
+        UbuntuSystemProfile
+      elsif File.exists?('/usr/share/doc/raspberrypi-bootloader-nokernel')
+        RaspbianSystemProfile
+      else
+        DebianSystemProfile
+      end
+    end
+
   end
 end

--- a/lib/babushka/system_profile.rb
+++ b/lib/babushka/system_profile.rb
@@ -149,7 +149,6 @@ module Babushka
     end
   end
 
-
   class DebianSystemProfile < LinuxSystemProfile
     def flavour_str; 'Debian' end
     def version; version_info end

--- a/lib/babushka/system_profile.rb
+++ b/lib/babushka/system_profile.rb
@@ -149,6 +149,7 @@ module Babushka
     end
   end
 
+
   class DebianSystemProfile < LinuxSystemProfile
     def flavour_str; 'Debian' end
     def version; version_info end
@@ -157,6 +158,10 @@ module Babushka
 
     def get_version_info; File.read('/etc/debian_version') end
     def pkg_helper; AptHelper end
+  end
+
+  class RaspbianSystemProfile < DebianSystemProfile;
+    def flavour_str; 'Raspbian' end
   end
 
   class UbuntuSystemProfile < LinuxSystemProfile

--- a/spec/babushka/apt_helper_spec.rb
+++ b/spec/babushka/apt_helper_spec.rb
@@ -61,5 +61,22 @@ describe Babushka::AptHelper do
         'http://lol.ec2.archive.ubuntu.com/ubuntu/'[matcher].should be_nil
       end
     end
+    context 'on raspbian' do
+      before {
+        Babushka.host.stub(:flavour).and_return(:raspbian)
+      }
+      it "should match the root mirror" do
+        'http://archive.raspbian.org/raspbian'[matcher].should_not be_nil
+      end
+      it "should match the mirror director" do
+        'http://mirrordirector.raspbian.org/raspbian'[matcher].should_not be_nil
+      end
+      it "should match a trailing slash" do
+        'http://mirrordirector.raspbian.org/raspbian/'[matcher].should_not be_nil
+      end
+      it "should not match other things" do
+        'http://ec2.archive.ubuntu.com/ubuntu/'[matcher].should be_nil
+      end
+    end
   end
 end

--- a/spec/babushka/system_detector_spec.rb
+++ b/spec/babushka/system_detector_spec.rb
@@ -32,6 +32,7 @@ describe Babushka::SystemDetector do
       it "should return DebianSystemProfile on Debian boxes" do
         File.should_receive(:exists?).with("/etc/debian_version").and_return(true)
         File.should_receive(:exists?).with("/etc/lsb-release").and_return(false)
+        File.should_receive(:exists?).with("/usr/share/doc/raspberrypi-bootloader-nokernel").and_return(false)
         subject.should be_an_instance_of(Babushka::DebianSystemProfile)
       end
       it "should return UbuntuSystemProfile on Ubuntu boxes" do
@@ -39,6 +40,12 @@ describe Babushka::SystemDetector do
         File.should_receive(:exists?).with("/etc/lsb-release").and_return(true)
         File.should_receive(:read).with("/etc/lsb-release").and_return('Ubuntu')
         subject.should be_an_instance_of(Babushka::UbuntuSystemProfile)
+      end
+      it "should return RaspbianSystemProfile on Raspbian boxes" do
+        File.should_receive(:exists?).with("/etc/debian_version").and_return(true)
+        File.should_receive(:exists?).with("/etc/lsb-release").and_return(false)
+        File.should_receive(:exists?).with("/usr/share/doc/raspberrypi-bootloader-nokernel").and_return(true)
+        subject.should be_an_instance_of(Babushka::RaspbianSystemProfile)
       end
       it "should return ArchSystemProfile on Arch boxes" do
         File.should_receive(:exists?).with("/etc/arch-release").and_return(true)


### PR DESCRIPTION
Raspbian is a Debian-derivative that supports the RaspberryPi. Some of
the apt mirrors are different between Debian and Raspbian. This patch
supports the known Raspbian mirror locations.