### PR TITLE
Add `lbaction` to the list of non-descendable file extensions

### DIFF
--- a/lib/babushka/asset.rb
+++ b/lib/babushka/asset.rb
@@ -71,7 +71,7 @@ module Babushka
 
     def content_subdir
       identity_dirs.reject {|dir|
-        %w[app pkg bundle tmbundle prefPane].map {|i|
+        %w[app pkg bundle tmbundle prefPane lbaction].map {|i|
           /\.#{i}$/
         }.any? {|dont_descend|
           dir[dont_descend]


### PR DESCRIPTION
These are LaunchBar extensions, distributed as Zip archives with an `.lbaction`, with a single top-level directory when extracted, also with an `.lbaction` extension. In order to make this top-level directory easy to move in one go, we don’t want to descend into it (e.g. exactly how Babushka also treats `tmbundle` directories).

Resolves #326, according to the discussion there.

Thanks for babushka! :smiley: 