### PR TITLE
Add Ubuntu 15.04 - 16.04 codename support

### DIFF
--- a/lib/babushka/system_definition.rb
+++ b/lib/babushka/system_definition.rb
@@ -69,6 +69,9 @@ module Babushka
           '13.10' => :saucy,
           '14.04' => :trusty,
           '14.10' => :utopic,
+          '15.04' => :vivd,
+          '15.10' => :wily,
+          '16.04' => :xenial,
         },
         :debian => {
           '4' => :etch,
@@ -138,6 +141,9 @@ module Babushka
           '13.10' => 'Saucy Salamander',
           '14.04' => 'Trusty Tahr',
           '14.10' => 'Utopic Unicorn',
+          '15.04' => 'Vivid Vervet',
+          '15.10' => 'Wily Werewolf',
+          '16.04' => 'Xenial Xerus',
         },
         :redhat => {
           '3' => 'Taroon',


### PR DESCRIPTION
I'm not sure where these are used, but if they're only needed to get the codename of the current release, that info is in '/etc/lsb_release':
```
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=15.10
DISTRIB_CODENAME=wily
DISTRIB_DESCRIPTION="Ubuntu 15.10"
```

Could we set the default using that somehow? E.g. overriding 'def codename' in UbuntuSystemProfile to return version.val_for('DISTRIB_CODENAME').