### PR TITLE
fixes #336 Update to handle newer homebrew installations formula location

### DIFF
--- a/lib/babushka/pkg_helpers/brew_helper.rb
+++ b/lib/babushka/pkg_helpers/brew_helper.rb
@@ -92,7 +92,11 @@ module Babushka
     end
 
     def formulas_path
-      prefix / 'Library/Formula'
+      if Dir.exist?(prefix / 'Library/Formula')
+        prefix / 'Library/Formula'
+      else
+        prefix / 'Homebrew/Library/Formula'
+      end
     end
 
     def taps_path

--- a/spec/babushka/brew_helper_spec.rb
+++ b/spec/babushka/brew_helper_spec.rb
@@ -64,22 +64,46 @@ From: https://github.com/mxcl/homebrew/commits/master/Library/Formula/readline.r
   end
 
   describe '#has_formula_for?' do
-    before {
-      allow(brew_helper).to receive(:prefix).and_return('/usr/local')
-      allow(Dir).to receive(:[]).with('/usr/local/Library/Formula/*.rb', '/usr/local/Library/Taps/**/*.rb').and_return([
-        '/usr/local/Library/Formula/zsh.rb',
-        '/usr/local/Library/Taps/homebrew-dupes/apple-gcc42.rb',
-        '/usr/local/Library/Taps/original-dev/Formula/redis.rb',
-      ])
-    }
-    it "should find both core and tapped packages" do
-      zsh = double('pkg', :name => 'zsh')
-      gcc42 = double('pkg', :name => 'homebrew/dupes/apple-gcc42')
-      redis = double('pkg', :name => 'original/dev/redis')
+    context 'when an older version of Homebrew is installed' do
+      before {
+        allow(brew_helper).to receive(:prefix).and_return('/usr/local')
+        allow(Dir).to receive(:exist?).and_return(true)
+        allow(Dir).to receive(:[]).with('/usr/local/Library/Formula/*.rb', '/usr/local/Library/Taps/**/*.rb').and_return([
+          '/usr/local/Library/Formula/zsh.rb',
+          '/usr/local/Library/Taps/homebrew-dupes/apple-gcc42.rb',
+          '/usr/local/Library/Taps/original-dev/Formula/redis.rb',
+        ])
+      }
+      it "should find both core and tapped packages" do
+        zsh = double('pkg', :name => 'zsh')
+        gcc42 = double('pkg', :name => 'homebrew/dupes/apple-gcc42')
+        redis = double('pkg', :name => 'original/dev/redis')
 
-      expect(brew_helper.send(:has_formula_for?, zsh)).to be_truthy
-      expect(brew_helper.send(:has_formula_for?, gcc42)).to be_truthy
-      expect(brew_helper.send(:has_formula_for?, redis)).to be_truthy
+        expect(brew_helper.send(:has_formula_for?, zsh)).to be_truthy
+        expect(brew_helper.send(:has_formula_for?, gcc42)).to be_truthy
+        expect(brew_helper.send(:has_formula_for?, redis)).to be_truthy
+      end
+    end
+
+    context 'when a newer version of Homebrew is installed' do
+      before {
+        allow(brew_helper).to receive(:prefix).and_return('/usr/local')
+        allow(Dir).to receive(:exist?).and_return(false)
+        allow(Dir).to receive(:[]).with('/usr/local/Homebrew/Library/Formula/*.rb', '/usr/local/Library/Taps/**/*.rb').and_return([
+          '/usr/local/Homebrew/Library/Formula/zsh.rb',
+          '/usr/local/Library/Taps/homebrew-dupes/apple-gcc42.rb',
+          '/usr/local/Library/Taps/original-dev/Formula/redis.rb',
+        ])
+      }
+      it "should find both core and tapped packages" do
+        zsh = double('pkg', :name => 'zsh')
+        gcc42 = double('pkg', :name => 'homebrew/dupes/apple-gcc42')
+        redis = double('pkg', :name => 'original/dev/redis')
+
+        expect(brew_helper.send(:has_formula_for?, zsh)).to be_truthy
+        expect(brew_helper.send(:has_formula_for?, gcc42)).to be_truthy
+        expect(brew_helper.send(:has_formula_for?, redis)).to be_truthy
+      end
     end
   end
 end


### PR DESCRIPTION
Use if it exists in `/usr/local/Library/Formula`. If not fall back to the new homebrew formula api in `/usr/local/Homebrew/Library/Formula`
