### PR TITLE
Use Gem::Specification to read gem version

### DIFF
--- a/lib/babushka/pkg_helpers/gem_helper.rb
+++ b/lib/babushka/pkg_helpers/gem_helper.rb
@@ -43,8 +43,8 @@ module Babushka
 
     def versions_of pkg
       pkg_name = pkg.respond_to?(:name) ? pkg.name : pkg
-      gemspecs_for(pkg_name).select {|i|
-        i.p.read.val_for('s.name')[/^[\'\"\%qQ\{]*#{pkg_name}[\'\"\}]*$/]
+      gemspecs_for(pkg_name).select {|path|
+        Gem::Specification::load(path).version
       }.map {|i|
         File.basename(i).scan(/^#{pkg_name}-(.*).gemspec$/).flatten.first
       }.map {|i|


### PR DESCRIPTION
This PR updates the method used to parse the version string from a gemspec file.

Previously, babushka was using a fairly strict regex to parse the version string. Unfortunately, this method breaks if the version string is frozen (as is now the case with all gemspecs). For example, this will not parse:

```
  s.name = "foo".frozen
```

The most future-proof solution seemed to be to use the `Gem::Specification` class to handle the version string parsing instead.