### PR TITLE
Correctly detect Raspbian

### DIFF
--- a/lib/babushka/system_detector.rb
+++ b/lib/babushka/system_detector.rb
@@ -34,7 +34,7 @@ module Babushka
     def self.detect_debian_derivative
       if File.exists?('/etc/lsb-release') && File.read('/etc/lsb-release')[/ubuntu/i]
         UbuntuSystemProfile
-      elsif File.exists?('/usr/share/doc/raspberrypi-bootloader-nokernel')
+      elsif File.exists?('/etc/os-release') && File.read('/etc/os-release')[/ID=raspbian/]
         RaspbianSystemProfile
       else
         DebianSystemProfile

--- a/spec/babushka/system_detector_spec.rb
+++ b/spec/babushka/system_detector_spec.rb
@@ -32,7 +32,8 @@ RSpec.describe Babushka::SystemDetector do
       it "should return DebianSystemProfile on Debian boxes" do
         expect(File).to receive(:exists?).with("/etc/debian_version").and_return(true)
         expect(File).to receive(:exists?).with("/etc/lsb-release").and_return(false)
-        expect(File).to receive(:exists?).with("/usr/share/doc/raspberrypi-bootloader-nokernel").and_return(false)
+        expect(File).to receive(:exists?).with("/etc/os-release").and_return(true)
+        expect(File).to receive(:read).with("/etc/os-release").and_return('ID=debian')
         expect(subject).to be_an_instance_of(Babushka::DebianSystemProfile)
       end
       it "should return UbuntuSystemProfile on Ubuntu boxes" do
@@ -44,7 +45,8 @@ RSpec.describe Babushka::SystemDetector do
       it "should return RaspbianSystemProfile on Raspbian boxes" do
         expect(File).to receive(:exists?).with("/etc/debian_version").and_return(true)
         expect(File).to receive(:exists?).with("/etc/lsb-release").and_return(false)
-        expect(File).to receive(:exists?).with("/usr/share/doc/raspberrypi-bootloader-nokernel").and_return(true)
+        expect(File).to receive(:exists?).with("/etc/os-release").and_return(true)
+        expect(File).to receive(:read).with("/etc/os-release").and_return('ID=raspbian')
         expect(subject).to be_an_instance_of(Babushka::RaspbianSystemProfile)
       end
       it "should return ArchSystemProfile on Arch boxes" do


### PR DESCRIPTION
The file `/usr/share/doc/raspberrypi-bootloader-nokernel` doesn't exists on my system.
`/etc/os-release` seems to be the preferred way to correctly determine that this is a Raspbian-system.