### PR TITLE
Update Ubuntu system definition codenames and descriptions

### DIFF
--- a/lib/babushka/system_definition.rb
+++ b/lib/babushka/system_definition.rb
@@ -72,6 +72,8 @@ module Babushka
           '15.04' => :vivid,
           '15.10' => :wily,
           '16.04' => :xenial,
+          '17.10' => :artful,
+          '18.04' => :bionic,
         },
         :debian => {
           '4' => :etch,
@@ -146,6 +148,8 @@ module Babushka
           '15.04' => 'Vivid Vervet',
           '15.10' => 'Wily Werewolf',
           '16.04' => 'Xenial Xerus',
+          '17.10' => 'Artful Aardvark',
+          '18.04' => 'Bionic Beaver',
         },
         :redhat => {
           '3' => 'Taroon',


### PR DESCRIPTION
I'm coming to this having been asked for `release?` by the `apt source` dep.

Keeping in mind I don't know what else system definitions might be used for, could the `SystemProfile` subclass provide the codename (if available), rather than maintaining the system definition list? In the case of `UbuntuSystemProfile`, this information is available:
```
>> Babushka.host.get_version_info
=> "DISTRIB_ID=Ubuntu\nDISTRIB_RELEASE=18.04\nDISTRIB_CODENAME=bionic\nDISTRIB_DESCRIPTION=\"Ubuntu 18.04 LTS\"\n"
```

If so, would a patch be welcome?