### PR TITLE
Allow curl to follow HTTP redirects itself when downloading resources

### DIFF
--- a/lib/babushka/resource.rb
+++ b/lib/babushka/resource.rb
@@ -31,22 +31,13 @@ module Babushka
       if filename.p.exists? && !filename.p.empty?
         log_ok "Already downloaded #{filename}."
         filename
-      elsif (result = shell(%Q{curl -I -X GET "#{url}"})).nil?
-        log_error "Couldn't download #{url}: `curl` exited with non-zero status."
       else
-        response_code = result.val_for(/HTTP\/1\.\d/) # not present for ftp://, etc.
-        if response_code && response_code[/^[23]/].nil?
-          log_error "Couldn't download #{url}: #{response_code}."
-        elsif !(location = result.val_for(/^location:/i)).nil?
-          log "Following redirect from #{url}"
-          download URI.escape(location), location.p.basename
-        else
-          success = log_block "Downloading #{url}" do
-            shell('curl', '-#', '-o', "#{filename}.tmp", url.to_s, :progress => /[\d\.]+%/) &&
+        success = log_block "Downloading #{url}" do
+          shell('curl', '-#', '-L', '-o' "#{filename}.tmp", url.to_s, :progress => /[\d\.]+%/) &&
             shell('mv', '-f', "#{filename}.tmp", filename)
-          end
-          filename if success
         end
+
+        filename if success
       end
     end
 


### PR DESCRIPTION
Hey @benhoskings 👋 

Still loving babushka. It recently helped me start fresh on a new Mac :)

In automating a few other bits of my setup, though, I encountered an issue – the current hand-rolled logic for detecting and following redirects would fail with redirect URLs that were already HTTP-escaped (e.g. redirect URLs from GitHub releases to their actual location on S3). It would end up double-escaping the URL and that would result in the request returning an error, instead of actually downloading the file.

I figured we could probably just let curl do its own thing and follow the redirects itself using its own `-L` option?

This will likely give us the most compatible behaviour possible, since curl is so widely used and battle tested?

Keen to hear your thoughts!

❤️ 