### PR TITLE
Add “.spoon” extension to the list of non-descendable directories

### DIFF
--- a/lib/babushka/asset.rb
+++ b/lib/babushka/asset.rb
@@ -71,7 +71,7 @@ module Babushka
 
     def content_subdir
       identity_dirs.reject {|dir|
-        %w[app pkg bundle tmbundle prefPane lbaction].map {|i|
+        %w[app pkg bundle tmbundle prefPane lbaction spoon].map {|i|
           /\.#{i}$/
         }.any? {|dont_descend|
           dir[dont_descend]


### PR DESCRIPTION
While I'm at it, I have one more PR for you, @benhoskings :)

These are [Hammerspoon](http://www.hammerspoon.org) [plugins](https://github.com/Hammerspoon/Spoons), and they should be handled like the other similar files in the current list (e.g. tmbundle, lbaction).

I know in #326 (some time ago now!) we discussed the idea of making this list easier to configure, but if you're happy to add _just one more extension_ for now, this'd let me automate another aspect of my personal system ;)

OTOH, I am certainly happy to take on the task of making this part of Babushka a little more flexible – just let me know!