### PR TITLE
Simplify BrewHelper; improve support for tap pkgs (“heroku/brew/heroku”)

### DIFF
--- a/spec/babushka/brew_helper_spec.rb
+++ b/spec/babushka/brew_helper_spec.rb
@@ -2,28 +2,6 @@ require 'spec_helper'
 
 RSpec.describe Babushka::BrewHelper do
   let(:brew_helper) { Babushka::BrewHelper }
-  describe '#active_version_of' do
-    context "when a version is active" do
-      before {
-        allow(brew_helper).to receive(:version_info_for).with('readline').and_return(
-          [['6.2.1', false], ['6.2.2', true], ['6.2.4', false]]
-        )
-      }
-      it "should return the active version" do
-        expect(brew_helper.send(:active_version_of, 'readline')).to eq('6.2.2')
-      end
-    end
-    context "when no version is active" do
-      before {
-        allow(brew_helper).to receive(:version_info_for).with('readline').and_return(
-          [['6.2.1', false], ['6.2.2', false], ['6.2.4', false]]
-        )
-      }
-      it "should be nil" do
-        expect(brew_helper.send(:active_version_of, 'readline')).to be_nil
-      end
-    end
-  end
 
   describe '#versions_of' do
     before {
@@ -60,56 +38,6 @@ From: https://github.com/mxcl/homebrew/commits/master/Library/Formula/readline.r
         ['6.2.2', true],
         ['6.2.4', false]
       ])
-    end
-  end
-
-  describe '#has_formula_for?' do
-    context "on old homebrew installations" do
-      before {
-        allow(brew_helper).to receive(:bin_path).and_return('/usr/local/bin')
-        allow(Dir).to receive(:exist?).with("/usr/local/Library/Formula").and_return(true)
-        allow(Dir).to receive(:[]).with(
-          '/usr/local/Library/Formula/*.rb',
-          '/usr/local/Library/Taps/**/*.rb'
-        ).and_return([
-          '/usr/local/Library/Formula/zsh.rb',
-          '/usr/local/Library/Taps/homebrew-dupes/apple-gcc42.rb',
-          '/usr/local/Library/Taps/original-dev/Formula/redis.rb',
-        ])
-      }
-      it "should find both core and tapped packages" do
-        zsh = double('pkg', :name => 'zsh')
-        gcc42 = double('pkg', :name => 'homebrew/dupes/apple-gcc42')
-        redis = double('pkg', :name => 'original/dev/redis')
-
-        expect(brew_helper.send(:has_formula_for?, zsh)).to be_truthy
-        expect(brew_helper.send(:has_formula_for?, gcc42)).to be_truthy
-        expect(brew_helper.send(:has_formula_for?, redis)).to be_truthy
-      end
-    end
-
-    context "on new homebrew installations" do
-      before {
-        allow(brew_helper).to receive(:bin_path).and_return('/usr/local/bin')
-        allow(Dir).to receive(:exist?).with("/usr/local/Library/Formula").and_return(false)
-        allow(Dir).to receive(:[]).with(
-          '/usr/local/Homebrew/Library/Formula/*.rb',
-          '/usr/local/Homebrew/Library/Taps/**/*.rb'
-        ).and_return([
-          '/usr/local/Homebrew/Library/Formula/zsh.rb',
-          '/usr/local/Homebrew/Library/Taps/homebrew-dupes/apple-gcc42.rb',
-          '/usr/local/Homebrew/Library/Taps/original-dev/Formula/redis.rb',
-        ])
-      }
-      it "should find both core and tapped packages" do
-        zsh = double('pkg', :name => 'zsh')
-        gcc42 = double('pkg', :name => 'homebrew/dupes/apple-gcc42')
-        redis = double('pkg', :name => 'original/dev/redis')
-
-        expect(brew_helper.send(:has_formula_for?, zsh)).to be_truthy
-        expect(brew_helper.send(:has_formula_for?, gcc42)).to be_truthy
-        expect(brew_helper.send(:has_formula_for?, redis)).to be_truthy
-      end
     end
   end
 end


### PR DESCRIPTION
👋 @benhoskings, more tweaks for you.

This one was motivated by a need to install the heroku CLI package via homebrew, which comes from a tap. So I needed a dep like this:

```ruby
dep "heroku.managed" do
  installs "heroku/brew/heroku"
  provides "heroku"
end
```

Previously, package names like “heroku/brew/heroku” would fail in the `BrewHelper.version_info_for` check, since the name with slashes does not appear in the installed package page (e.g. “/usr/local/Cellar/heroku”).

Along with this, remove some manual package presence checks that require intimate knowledge of the directory structure of any given homebrew installation. I feel it would be better and more informative for the `.install_pkgs!` commands to fail noisily and print their error message instead. (Removing this check is another necessary step for packages like “heroku/brew/heroku” to install properly).

Overall, this reduces the complexity of BrewHelper and will make it more resilient to any internal changes to homebrew that may occur in the future.

For reference, here's what the output looks like now when an installation fails due to a misnamed package:

```
$ babushka icelab:heroku.managed
icelab:heroku.managed {
  homebrew {
    build tools {
      xcode tools {
        'cc', 'gcc', 'c++' & 'g++' run from /usr/bin.
        'clang', 'make', 'ld' & 'libtool' run from /usr/bin.
      } ✓ xcode tools
    } ✓ build tools
    'brew' runs from /usr/local/bin.
  } ✓ homebrew
  $ brew info heroku/brew/heroku-nope-not-there {
    Error: No available formula with the name "heroku/brew/heroku-nope-not-there"
    Warning: heroku/brew is shallow clone. To get complete history run:
      git -C "$(brew --repo heroku/brew)" fetch --unshallow

    Error: No previously deleted formula found.
  } ✗ shell command failed
  system doesn't have heroku/brew/heroku-nope-not-there brew
  meet {
    Installing heroku/brew/heroku-nope-not-there via brew {
      Error: No available formula with the name "heroku/brew/heroku-nope-not-there"
      ==> Searching for a previously deleted formula (in the last month)...
      Warning: heroku/brew is shallow clone. To get complete history run:
        git -C "$(brew --repo heroku/brew)" fetch --unshallow

      Error: No previously deleted formula found.
      Error: No similarly named formulae found.
      ==> Searching for similarly named formulae...
    }
  }
  $ brew info heroku/brew/heroku-nope-not-there {
    Error: No available formula with the name "heroku/brew/heroku-nope-not-there"
    Warning: heroku/brew is shallow clone. To get complete history run:
      git -C "$(brew --repo heroku/brew)" fetch --unshallow

    Error: No previously deleted formula found.
  } ✗ shell command failed
  system doesn't have heroku/brew/heroku-nope-not-there brew
} ✗ icelab:heroku.managed
You can view a more detailed log at '/Users/tim/.babushka/logs/icelab:heroku.managed'.
```