### PR TITLE
Bug - Newer versions of Ruby do not implicitly include URI.

### DIFF
--- a/lib/babushka/resource.rb
+++ b/lib/babushka/resource.rb
@@ -1,3 +1,5 @@
+require 'uri'
+
 module Babushka
   class Resource
     extend LogHelpers


### PR DESCRIPTION
Patch to explicitly require URI in resource.

We'd noticed that using Ruby versions newer than `2.4.4` for some reason don't have URI being automatically included.